### PR TITLE
Disable GoDown. Spaces in filenames. Default Home. Examples.

### DIFF
--- a/examples/NoHome/Filename With Spaces.md
+++ b/examples/NoHome/Filename With Spaces.md
@@ -1,0 +1,64 @@
+# Directories with a Home.md are bundled together
+
+When the `smartdownpreview` Sublime Plugin is invoked upon a target file (i.e., the file being edited), the Plugin will detect whether there is a `Home.md` file in the same directory as the target file. If so, then the contents of the directory will be included in the output HTML. This includes common media types (PNG, GIF, SVG, JPG) that are located within the directory containing Home.md.
+
+This behavior only occurs when a `Home.md` exists.
+
+## Smartdown Tunnels
+
+Using the syntax:
+
+```markdown
+[](:@Other)
+```
+
+we can build a Smartdown Tunnel to the card stored in file `Other.md`.
+
+[Go to Other](:@Other)
+
+## Hypercube SVG Remotely
+
+![](/media/hypercube)
+
+## Tickle example with Global mode Syntax
+
+```P5JS/playable/autoplay
+var message = "tickle",
+  font,
+  bounds, // holds x, y, w, h of the text's bounding box
+  fontsize = 60,
+  x, y; // x and y coordinates of the text
+
+function preload() {
+  font = loadFont('https://smartdown.site/gallery/resources/SourceSansPro-Regular.otf');
+}
+
+function setup() {
+  createCanvas(410, 250);
+
+  // set up the font
+  textFont(font);
+  textSize(fontsize);
+
+  // get the width and height of the text so we can center it initially
+  bounds = font.textBounds(message, 0, 0, fontsize);
+  x = width / 2 - bounds.w / 2;
+  y = height / 2 - bounds.h / 2;
+}
+
+function draw() {
+  background(204, 120);
+
+  // write the text in black and get its bounding box
+  fill(0);
+  text(message, x, y);
+  bounds = font.textBounds(message,x,y,fontsize);
+
+  // check if the mouse is inside the bounding box and tickle if so
+  if ( mouseX >= bounds.x && mouseX <= bounds.x + bounds.w &&
+    mouseY >= bounds.y && mouseY <= bounds.y + bounds.h) {
+    x += random(-5, 5);
+    y += random(-5, 5);
+  }
+}
+```

--- a/examples/NoHome/Media With Spaces.svg
+++ b/examples/NoHome/Media With Spaces.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="svg8668" xmlns:svg="http://www.w3.org/2000/svg"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="417px" height="453px"
+	 viewBox="0 0 417 453" enable-background="new 0 0 417 453" xml:space="preserve">
+<linearGradient id="path11377_2_" gradientUnits="userSpaceOnUse" x1="522.387" y1="24.2009" x2="154.6297" y2="292.5472" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.1794 315.625)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path11377_1_" opacity="0.5" fill="url(#path11377_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M172.944,211.051L166.702,0.979l248.909,58.408l-28.8,221.732L172.944,211.051z"/>
+<linearGradient id="path10484_2_" gradientUnits="userSpaceOnUse" x1="145.0564" y1="148.6057" x2="328.6494" y2="-189.5742" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.1794 315.625)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path10484_1_" opacity="0.5" fill="url(#path10484_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M36.842,350.894l136.102-139.843l213.868,70.068L279.73,452.142L36.842,350.894z"/>
+<linearGradient id="path10474_2_" gradientUnits="userSpaceOnUse" x1="-40.1111" y1="17.8958" x2="287.8506" y2="300.4517" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.1794 315.625)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path10474_1_" opacity="0.5" fill="url(#path10474_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257L166.702,0.979l6.241,210.072L36.842,350.894L1.162,118.257z"/>
+<linearGradient id="path19493_2_" gradientUnits="userSpaceOnUse" x1="149.1438" y1="116.4739" x2="447.9268" y2="27.0944" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.5557)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path19493_1_" opacity="0.5" fill="url(#path19493_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M172.944,211.051l21.726-1.167l116.559,35.574l75.583,35.661L172.944,211.051z"/>
+<linearGradient id="path19495_2_" gradientUnits="userSpaceOnUse" x1="459.8958" y1="326.8367" x2="334.4387" y2="37.8337" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.5557)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path19495_1_" opacity="0.5" fill="url(#path19495_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M311.229,245.458l3.607-109.354l100.775-76.717l-28.8,221.732L311.229,245.458z"/>
+<linearGradient id="path20386_2_" gradientUnits="userSpaceOnUse" x1="168.3376" y1="326.0105" x2="209.6072" y2="84.3857" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.5557)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path20386_1_" opacity="0.5" fill="url(#path20386_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M166.702,0.979l6.241,210.072l21.726-1.167l-1.06-107.075L166.702,0.979z"/>
+<linearGradient id="path20427_2_" gradientUnits="userSpaceOnUse" x1="322.0745" y1="131.8552" x2="347.8477" y2="-205.259" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path20427_1_" opacity="0.5" fill="url(#path20427_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M311.229,245.458l-62.787,81.55l31.288,125.135l107.082-171.023L311.229,245.458z"/>
+<linearGradient id="path21310_2_" gradientUnits="userSpaceOnUse" x1="167.7576" y1="146.5012" x2="91.8281" y2="-73.2141" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path21310_1_" opacity="0.5" fill="url(#path21310_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M36.842,350.894l89.888-68.092l67.94-72.918l-21.726,1.167L36.842,350.894z"/>
+<path id="path14961_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M194.67,209.884l-1.06-107.075l121.226,33.295l-3.607,109.354L194.67,209.884z"/>
+<linearGradient id="path14078_2_" gradientUnits="userSpaceOnUse" x1="217.1926" y1="187.2239" x2="245.8949" y2="-56.6075" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.2365 315.8447)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path14078_1_" opacity="0.5" fill="url(#path14078_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M194.67,209.884l-67.94,72.918l121.712,44.205l62.787-81.55L194.67,209.884z"/>
+<path id="path13195_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M193.61,102.809l1.06,107.075l-67.94,72.918l-6.826-113.937L193.61,102.809z"/>
+<linearGradient id="path11419_2_" gradientUnits="userSpaceOnUse" x1="260.512" y1="266.5662" x2="196.0303" y2="36.813" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.2365 315.8447)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path11419_1_" opacity="0.5" fill="url(#path11419_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M119.904,168.866l73.707-66.057l121.226,33.295l-63.432,73.928L119.904,168.866z"/>
+<linearGradient id="path11421_2_" gradientUnits="userSpaceOnUse" x1="312.5432" y1="214.7561" x2="277.7656" y2="-43.1907" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.2365 315.8447)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path11421_1_" opacity="0.5" fill="url(#path11421_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M251.405,210.032l-2.963,116.976l62.787-81.55l3.607-109.354L251.405,210.032z"/>
+<linearGradient id="path12312_2_" gradientUnits="userSpaceOnUse" x1="206.1077" y1="190.8357" x2="191.8469" y2="-35.1273" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.2365 315.8447)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path12312_1_" opacity="0.5" fill="url(#path12312_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M119.904,168.866l131.501,41.166l-2.963,116.976l-121.712-44.205L119.904,168.866z"/>
+<linearGradient id="path16799_2_" gradientUnits="userSpaceOnUse" x1="293.0696" y1="352.447" x2="331.0429" y2="141.3536" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.0456 315.749)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path16799_1_" opacity="0.5" fill="url(#path16799_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M166.702,0.979l248.909,58.408l-100.775,76.717L193.61,102.809L166.702,0.979z"/>
+<linearGradient id="path15916_2_" gradientUnits="userSpaceOnUse" x1="310.4836" y1="251.2878" x2="384.3213" y2="110.8986" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.0456 315.749)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path15916_1_" opacity="0.5" fill="url(#path15916_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M251.405,210.032l63.432-73.928l100.775-76.717l-122.093,150.34L251.405,210.032z"/>
+<linearGradient id="path17682_2_" gradientUnits="userSpaceOnUse" x1="66.1721" y1="327.9207" x2="156.2252" y2="124.3266" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.0456 315.749)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path17682_1_" opacity="0.5" fill="url(#path17682_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257L166.702,0.979l26.908,101.83l-73.707,66.057L1.162,118.257z"/>
+<linearGradient id="path9576_2_" gradientUnits="userSpaceOnUse" x1="142.1912" y1="89.0706" x2="186.9942" y2="235.6841" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.0456 315.749)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path9576_1_" opacity="0.5" fill="url(#path9576_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257l118.741,50.609l131.501,41.166l42.114-0.305L1.162,118.257z"/>
+<linearGradient id="path18579_2_" gradientUnits="userSpaceOnUse" x1="50.5022" y1="195.6179" x2="121.1542" y2="-41.5611" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path18579_1_" opacity="0.5" fill="url(#path18579_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257l118.741,50.609l6.826,113.937l-89.888,68.092L1.162,118.257z"/>
+<linearGradient id="path19462_2_" gradientUnits="userSpaceOnUse" x1="280.9104" y1="126.1584" x2="294.4901" y2="-162.0327" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path19462_1_" opacity="0.5" fill="url(#path19462_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M293.519,209.727l-42.114,0.305l-2.963,116.976l31.288,125.135L293.519,209.727z"/>
+<linearGradient id="path19472_2_" gradientUnits="userSpaceOnUse" x1="201.5037" y1="93.9871" x2="160.3339" y2="-156.0503" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path19472_1_" opacity="0.5" fill="url(#path19472_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M126.729,282.802l121.712,44.205l31.288,125.135L36.842,350.894L126.729,282.802z"/>
+<path id="path8686_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257L166.702,0.979l248.909,58.408l-122.093,150.34L1.162,118.257z"/>
+<path id="path10461_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257l35.679,232.638L279.73,452.142l13.789-242.416L1.162,118.257z"/>
+<path id="path10494_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M279.73,452.142l13.789-242.416l122.093-150.34l-28.8,221.732L279.73,452.142z"/>
+</svg>

--- a/examples/NoHome/Other.md
+++ b/examples/NoHome/Other.md
@@ -1,0 +1,16 @@
+# Directories with a Home.md are bundled together
+
+When the `smartdownpreview` Sublime Plugin is invoked upon a target file (i.e., the file being edited), the Plugin will detect whether there is a `Home.md` file in the same directory as the target file. If not, then the other `.md` files in the directory will be included in the output HTML. However, without a `Home.md`, the co-located media files (PNG, GIF, SVG, JPG) in the same directory will be ignored, and not bundled with the output.
+
+
+## Smartdown Tunnels
+
+Using the syntax:
+
+```markdown
+[](:@Filename-With-Spaces)
+```
+
+we can build a Smartdown Tunnel to the card stored in file `Filename With Spaces.md`.
+
+[Go to Filename-With-Spaces](:@Filename-With-Spaces)

--- a/examples/WithHome/Home.md
+++ b/examples/WithHome/Home.md
@@ -1,0 +1,80 @@
+# Directories with a Home.md are bundled together
+
+When the `smartdownpreview` Sublime Plugin is invoked upon a target file (i.e., the file being edited), the Plugin will detect whether there is a `Home.md` file in the same directory as the target file. If so, then the contents of the directory will be included in the output HTML. This includes common media types (PNG, GIF, SVG, JPG) that are located within the directory containing Home.md.
+
+This behavior only occurs when a `Home.md` exists.
+
+## Smartdown Tunnels
+
+Using the syntax:
+
+```markdown
+[](:@Other-Card-With-Spaces)
+```
+
+we can build a Smartdown Tunnel to the card stored in file `Other Card With Spaces.md`.
+
+[Go to Other-Card-With-Spaces](:@Other-Card-With-Spaces)
+
+## Hypercube SVG Remotely
+
+![](/media/hypercube)
+
+
+
+## Hypercube SVG Locally
+
+Because there is a `Home.md` in the same directory as this file, all of the `.md` and media files will be bundled. For example, the media file `Media With Spaces.svg` can be referred to with the syntax:
+
+```markdown
+![](/block/Media-With-Spaces.svg)
+```
+
+as below:
+
+![](/block/Media-With-Spaces.svg)
+
+
+
+## Tickle example with Global mode Syntax
+
+```P5JS/playable/autoplay
+var message = "tickle",
+  font,
+  bounds, // holds x, y, w, h of the text's bounding box
+  fontsize = 60,
+  x, y; // x and y coordinates of the text
+
+function preload() {
+  font = loadFont('https://smartdown.site/gallery/resources/SourceSansPro-Regular.otf');
+}
+
+function setup() {
+  createCanvas(410, 250);
+
+  // set up the font
+  textFont(font);
+  textSize(fontsize);
+
+  // get the width and height of the text so we can center it initially
+  bounds = font.textBounds(message, 0, 0, fontsize);
+  x = width / 2 - bounds.w / 2;
+  y = height / 2 - bounds.h / 2;
+}
+
+function draw() {
+  background(204, 120);
+
+  // write the text in black and get its bounding box
+  fill(0);
+  text(message, x, y);
+  bounds = font.textBounds(message,x,y,fontsize);
+
+  // check if the mouse is inside the bounding box and tickle if so
+  if ( mouseX >= bounds.x && mouseX <= bounds.x + bounds.w &&
+    mouseY >= bounds.y && mouseY <= bounds.y + bounds.h) {
+    x += random(-5, 5);
+    y += random(-5, 5);
+  }
+}
+```

--- a/examples/WithHome/Media With Spaces.svg
+++ b/examples/WithHome/Media With Spaces.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="svg8668" xmlns:svg="http://www.w3.org/2000/svg"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="417px" height="453px"
+	 viewBox="0 0 417 453" enable-background="new 0 0 417 453" xml:space="preserve">
+<linearGradient id="path11377_2_" gradientUnits="userSpaceOnUse" x1="522.387" y1="24.2009" x2="154.6297" y2="292.5472" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.1794 315.625)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path11377_1_" opacity="0.5" fill="url(#path11377_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M172.944,211.051L166.702,0.979l248.909,58.408l-28.8,221.732L172.944,211.051z"/>
+<linearGradient id="path10484_2_" gradientUnits="userSpaceOnUse" x1="145.0564" y1="148.6057" x2="328.6494" y2="-189.5742" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.1794 315.625)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path10484_1_" opacity="0.5" fill="url(#path10484_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M36.842,350.894l136.102-139.843l213.868,70.068L279.73,452.142L36.842,350.894z"/>
+<linearGradient id="path10474_2_" gradientUnits="userSpaceOnUse" x1="-40.1111" y1="17.8958" x2="287.8506" y2="300.4517" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.1794 315.625)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path10474_1_" opacity="0.5" fill="url(#path10474_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257L166.702,0.979l6.241,210.072L36.842,350.894L1.162,118.257z"/>
+<linearGradient id="path19493_2_" gradientUnits="userSpaceOnUse" x1="149.1438" y1="116.4739" x2="447.9268" y2="27.0944" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.5557)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path19493_1_" opacity="0.5" fill="url(#path19493_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M172.944,211.051l21.726-1.167l116.559,35.574l75.583,35.661L172.944,211.051z"/>
+<linearGradient id="path19495_2_" gradientUnits="userSpaceOnUse" x1="459.8958" y1="326.8367" x2="334.4387" y2="37.8337" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.5557)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path19495_1_" opacity="0.5" fill="url(#path19495_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M311.229,245.458l3.607-109.354l100.775-76.717l-28.8,221.732L311.229,245.458z"/>
+<linearGradient id="path20386_2_" gradientUnits="userSpaceOnUse" x1="168.3376" y1="326.0105" x2="209.6072" y2="84.3857" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.5557)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path20386_1_" opacity="0.5" fill="url(#path20386_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M166.702,0.979l6.241,210.072l21.726-1.167l-1.06-107.075L166.702,0.979z"/>
+<linearGradient id="path20427_2_" gradientUnits="userSpaceOnUse" x1="322.0745" y1="131.8552" x2="347.8477" y2="-205.259" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path20427_1_" opacity="0.5" fill="url(#path20427_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M311.229,245.458l-62.787,81.55l31.288,125.135l107.082-171.023L311.229,245.458z"/>
+<linearGradient id="path21310_2_" gradientUnits="userSpaceOnUse" x1="167.7576" y1="146.5012" x2="91.8281" y2="-73.2141" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path21310_1_" opacity="0.5" fill="url(#path21310_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M36.842,350.894l89.888-68.092l67.94-72.918l-21.726,1.167L36.842,350.894z"/>
+<path id="path14961_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M194.67,209.884l-1.06-107.075l121.226,33.295l-3.607,109.354L194.67,209.884z"/>
+<linearGradient id="path14078_2_" gradientUnits="userSpaceOnUse" x1="217.1926" y1="187.2239" x2="245.8949" y2="-56.6075" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.2365 315.8447)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path14078_1_" opacity="0.5" fill="url(#path14078_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M194.67,209.884l-67.94,72.918l121.712,44.205l62.787-81.55L194.67,209.884z"/>
+<path id="path13195_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M193.61,102.809l1.06,107.075l-67.94,72.918l-6.826-113.937L193.61,102.809z"/>
+<linearGradient id="path11419_2_" gradientUnits="userSpaceOnUse" x1="260.512" y1="266.5662" x2="196.0303" y2="36.813" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.2365 315.8447)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path11419_1_" opacity="0.5" fill="url(#path11419_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M119.904,168.866l73.707-66.057l121.226,33.295l-63.432,73.928L119.904,168.866z"/>
+<linearGradient id="path11421_2_" gradientUnits="userSpaceOnUse" x1="312.5432" y1="214.7561" x2="277.7656" y2="-43.1907" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.2365 315.8447)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path11421_1_" opacity="0.5" fill="url(#path11421_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M251.405,210.032l-2.963,116.976l62.787-81.55l3.607-109.354L251.405,210.032z"/>
+<linearGradient id="path12312_2_" gradientUnits="userSpaceOnUse" x1="206.1077" y1="190.8357" x2="191.8469" y2="-35.1273" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.2365 315.8447)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path12312_1_" opacity="0.5" fill="url(#path12312_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M119.904,168.866l131.501,41.166l-2.963,116.976l-121.712-44.205L119.904,168.866z"/>
+<linearGradient id="path16799_2_" gradientUnits="userSpaceOnUse" x1="293.0696" y1="352.447" x2="331.0429" y2="141.3536" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.0456 315.749)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path16799_1_" opacity="0.5" fill="url(#path16799_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M166.702,0.979l248.909,58.408l-100.775,76.717L193.61,102.809L166.702,0.979z"/>
+<linearGradient id="path15916_2_" gradientUnits="userSpaceOnUse" x1="310.4836" y1="251.2878" x2="384.3213" y2="110.8986" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.0456 315.749)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path15916_1_" opacity="0.5" fill="url(#path15916_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M251.405,210.032l63.432-73.928l100.775-76.717l-122.093,150.34L251.405,210.032z"/>
+<linearGradient id="path17682_2_" gradientUnits="userSpaceOnUse" x1="66.1721" y1="327.9207" x2="156.2252" y2="124.3266" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.0456 315.749)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path17682_1_" opacity="0.5" fill="url(#path17682_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257L166.702,0.979l26.908,101.83l-73.707,66.057L1.162,118.257z"/>
+<linearGradient id="path9576_2_" gradientUnits="userSpaceOnUse" x1="142.1912" y1="89.0706" x2="186.9942" y2="235.6841" gradientTransform="matrix(1.0003 0 0 -1.0002 -14.0456 315.749)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path9576_1_" opacity="0.5" fill="url(#path9576_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257l118.741,50.609l131.501,41.166l42.114-0.305L1.162,118.257z"/>
+<linearGradient id="path18579_2_" gradientUnits="userSpaceOnUse" x1="50.5022" y1="195.6179" x2="121.1542" y2="-41.5611" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path18579_1_" opacity="0.5" fill="url(#path18579_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257l118.741,50.609l6.826,113.937l-89.888,68.092L1.162,118.257z"/>
+<linearGradient id="path19462_2_" gradientUnits="userSpaceOnUse" x1="280.9104" y1="126.1584" x2="294.4901" y2="-162.0327" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path19462_1_" opacity="0.5" fill="url(#path19462_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M293.519,209.727l-42.114,0.305l-2.963,116.976l31.288,125.135L293.519,209.727z"/>
+<linearGradient id="path19472_2_" gradientUnits="userSpaceOnUse" x1="201.5037" y1="93.9871" x2="160.3339" y2="-156.0503" gradientTransform="matrix(1.0003 0 0 -1.0002 -13.7155 315.999)">
+	<stop  offset="0" style="stop-color:#247CD5"/>
+	<stop  offset="1" style="stop-color:#69DDEA"/>
+</linearGradient>
+<path id="path19472_1_" opacity="0.5" fill="url(#path19472_2_)" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M126.729,282.802l121.712,44.205l31.288,125.135L36.842,350.894L126.729,282.802z"/>
+<path id="path8686_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257L166.702,0.979l248.909,58.408l-122.093,150.34L1.162,118.257z"/>
+<path id="path10461_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M1.162,118.257l35.679,232.638L279.73,452.142l13.789-242.416L1.162,118.257z"/>
+<path id="path10494_1_" opacity="0.5" fill="none" stroke="#000000" stroke-linejoin="bevel" enable-background="new    " d="
+	M279.73,452.142l13.789-242.416l122.093-150.34l-28.8,221.732L279.73,452.142z"/>
+</svg>

--- a/examples/WithHome/Other Card With Spaces.md
+++ b/examples/WithHome/Other Card With Spaces.md
@@ -1,0 +1,32 @@
+# Testing Whether Spaces in Filenames Work
+
+This file `Other Card With Spaces.md` is encoded with id `Other-Card-With-Spaces.md`, so that it can be referred to with Smartdown tunnel syntax:
+
+```markdown
+[](:@Other-Card-With-Spaces)
+```
+
+
+## Hypercube SVG Remotely
+
+![](/media/hypercube)
+
+
+
+## Hypercube SVG Locally
+
+Because there is a `Home.md` in the same directory as this file, all of the `.md` and media files will be bundled. For example, the media file `Media With Spaces.svg` can be referred to with the syntax:
+
+```markdown
+![](/block/Media-With-Spaces.svg)
+```
+
+as below:
+
+![](/block/Media-With-Spaces.svg)
+
+
+---
+
+[Go Home](:@Home)
+

--- a/smartdown_template.html
+++ b/smartdown_template.html
@@ -19,11 +19,12 @@
   </script>
   <script src="http://127.0.0.1:8484/godown.js"></script>
 -->
-
+<!--
   <script>
     window.godownBase = 'https://rawgit.com/DoctorBud/godown/master/godown/';
   </script>
   <script src="https://rawgit.com/DoctorBud/godown/master/godown/godown.js"></script>
+-->
 
   <script src="smartdown.js"></script>
   <script src="calc_handlers.js"></script>
@@ -43,6 +44,9 @@
     </div>
   </div>
 
+  <script>
+    window.smartdownDefaultHome = '${base}';
+  </script>
   <script src="inline_helper.js"></script>
   <script>
     smartdown.setLinkRules([


### PR DESCRIPTION
- Disable inclusion of GoDown by default.
- Transform spaces to hyphens when they occur in filenames (.md or media files).
- Fix template so that the Smartdown default home card is set to the currently edited target card.
- Add examples and explanations of multi-card projects and the use of Home.md to bundle media in the output.
